### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ class ServerlessCommandLineEventArgs {
         options: {
           event: {
             usage: 'Event JSON passes function (e.g. --event \'{"foo":"var"}\' or -e \'{"foo":"var"}\')',
-            shortcut: 'e'
+            shortcut: 'e',
+            type: 'string',
           }
         }
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessCommandLineEventArgs for "event"
```